### PR TITLE
feat: list/delete created environments

### DIFF
--- a/src/commands/check/index.ts
+++ b/src/commands/check/index.ts
@@ -64,7 +64,7 @@ export function check_ts_version() {
 export function check_c_version() {
     try {
         if (!cache.has("c")) {
-            const raw = run("gcc --version").split("\n")[0];
+            const raw = run("gcc --version").replace(/\s+/g, " ");
             const result = semver().exec(raw)?.[0];
             if (result) {
                 cache.set("c", (raw.includes("clang") ? "clang " : "gcc ") + result);
@@ -80,7 +80,7 @@ export function check_c_version() {
 export function check_cpp_version() {
     try {
         if (!cache.has("cpp")) {
-            const raw = run("g++ --version").split("\n")[0];
+            const raw = run("g++ --version").replace(/\s+/g, " ");
             const result = semver().exec(raw)?.[0];
             if (result) {
                 cache.set("cpp", (raw.includes("clang") ? "clang " : "g++ ") + result);

--- a/src/commands/env/index.ts
+++ b/src/commands/env/index.ts
@@ -1,0 +1,27 @@
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import { OptionValues, Command } from "commander";
+
+export default async function env(opts: OptionValues, cmd: Command) {
+    const envs = fs.readdirSync(os.tmpdir()).filter((x) => x.startsWith("ncaic-"));
+
+    if (envs.length) {
+        const padding = Math.log10(envs.length) + 1;
+        for (let i = 0; i < envs.length; i++) {
+            const dir = path.resolve(os.tmpdir(), envs[i]);
+            console.log(`${(i + 1).toString().padStart(padding)}. ${dir}`);
+        }
+
+        if (opts.remove) {
+            console.log("---");
+            for (let i = 0; i < envs.length; i++) {
+                const dir = path.resolve(os.tmpdir(), envs[i]);
+                fs.rmSync(dir, { recursive: true });
+                console.log(`Removed ${dir}`);
+            }
+        }
+    } else {
+        console.log("No environments found");
+    }
+}

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -83,7 +83,10 @@ export function compile(source: string) {
  * @returns The absolute path of the temporary directory.
  */
 export function create_env(source: string) {
-    const dir = path.resolve(tmpdir(), Math.random().toString().slice(2));
+    const dir = path.resolve(
+        tmpdir(),
+        "ncaic-" + Math.random().toString().slice(2, 8).padEnd(6, "0"),
+    );
     if (fs.existsSync(dir)) {
         fs.rmSync(dir, { recursive: true });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import init from "./commands/init";
 import verify from "./commands/verify";
 import test from "./commands/test";
 import run from "./commands/run";
+import env from "./commands/env";
 
 const package_info = JSON.parse(
     fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"),
@@ -15,6 +16,12 @@ const package_info = JSON.parse(
 const program = new commander.Command().version(`${package_info.name} ${package_info.version}`);
 
 program.command("check").description("check for language support").action(check);
+
+program
+    .command("env")
+    .description("list created all environments")
+    .option("-r, --remove", "remove all environments after listing")
+    .action(env);
 
 program
     .command("init")


### PR DESCRIPTION
This PR introduces a new command `env` and its option `-r` (`--remove`), which is able to locate the created temp environments and optionally deletes them.

This PR also fix the bug of C / C++ language support detection on Windows.
