### PR TITLE
chore: upgrade cloudflared to `0.3.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "author": "JacobLinCool <jacoblincool@gmail.com> (https://github.com/JacobLinCool)",
     "license": "MIT",
     "dependencies": {
-        "cloudflared": "^0.2.2",
+        "cloudflared": "^0.3.1",
         "commander": "^9.3.0",
         "js-yaml": "^4.1.0",
         "pidusage": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ specifiers:
   '@types/js-yaml': ^4.0.5
   '@types/pidusage': ^2.0.2
   '@types/ws': ^8.5.3
-  cloudflared: ^0.2.2
+  cloudflared: ^0.3.1
   commander: ^9.3.0
   esno: ^0.16.3
   js-yaml: ^4.1.0
@@ -17,7 +17,7 @@ specifiers:
   yup: ^0.32.11
 
 dependencies:
-  cloudflared: 0.2.2
+  cloudflared: 0.3.1
   commander: 9.3.0
   js-yaml: 4.1.0
   pidusage: 3.0.0
@@ -491,8 +491,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /cloudflared/0.2.2:
-    resolution: {integrity: sha512-r6fmraXjaOF9Ay4wNvyhCFBlM/RThDO343MWxFcCq3YN0vkx68wTQERthJ+jPt03AjVMUNbq41R+2u3xavoVdA==}
+  /cloudflared/0.3.1:
+    resolution: {integrity: sha512-qSv3fPgc6oMQdcx6aEzQnodLrdKAEJoXRfyAcBUsNYLmD6wC/INY1LoVsMPdEXfB9KF69PBeIm/9cAtlG4d0pA==}
     hasBin: true
     requiresBuild: true
     dev: false


### PR DESCRIPTION
This PR fix an upstream bug of racing condition access during postinstall stage.